### PR TITLE
fix: traverse failure when empty root node

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -269,7 +269,7 @@ type NodeIterator struct {
 
 // NewNodeIterator returns a new NodeIterator to traverse the tree of the root node.
 func NewNodeIterator(rootKey []byte, ndb *nodeDB) (*NodeIterator, error) {
-	if rootKey == nil {
+	if len(rootKey) == 0 {
 		return &NodeIterator{
 			nodesToVisit: []*Node{},
 			ndb:          ndb,


### PR DESCRIPTION
This PR fixes "node does not have a hash" error when root node (from traverseStateChanges's iterator) is empty byte array.
